### PR TITLE
losetup: Added examples for partscan and read-only

### DIFF
--- a/pages/linux/losetup.md
+++ b/pages/linux/losetup.md
@@ -17,3 +17,11 @@
 - Detach a given loop device:
 
 `sudo losetup -d /dev/{{loop}}`
+
+- Attach a file to the new free loop device. Scan the device for partitions:
+
+`sudo losetup --show --partscan -f /{{path/to/file}}`
+
+- Attach a file to a read-only loop device:
+
+`sudo losetup --read-only /dev/{{loop}} /{{path/to/file}}`


### PR DESCRIPTION
read-only losetup and partscan are commonly used options in digital forensics. It is benefitial to know about '--partscan' as it sometimes gives other results then losetup and partprobe/kpartx, e.g. with BSD-style partitions.

- [x] The page has 8 or fewer examples.
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#commit-message).
- [x] The page follows the [content guidelines](/tldr-pages/tldr/blob/master/CONTRIBUTING.md#guidelines).
